### PR TITLE
Windows requires /Zc:preprocessor when using C++20

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ void test_custom_object() {
         "get_name", STRING_CHECK(custom_object->get_name(), "WrongName"),
         "get_custom_function", VAR_CHECK(custom_object->get_custom_function(), "CustomFunctionReturn")
     )
-    TEST_OBJECT_END(custom_object) // TEST_OBJECT_END must be put at the end of the thing TEST_OBJECT is testing so it can clean itself up. 
+    TEST_OBJECT_END(custom_object) // TEST_OBJECT_END must be put at the end of the thing TEST_OBJECT is testing so it can clean itself up.
 }
 
 void test_custom_scene() {
@@ -134,6 +134,7 @@ def generate(env):
     if env.get("is_msvc", False):
         env["CXXFLAGS"].remove("/std:c++17")
         env["CXXFLAGS"].insert(0, "/std:c++20")
+        env["CXXFLAGS"].insert(0, "/Zc:preprocessor")
     else:
         env["CXXFLAGS"].remove("-std=c++17")
         env["CXXFLAGS"].insert(0, "-std=c++20")

--- a/demo/SConstruct
+++ b/demo/SConstruct
@@ -22,6 +22,7 @@ def generate(env):
     if env.get("is_msvc", False):
         env["CXXFLAGS"].remove("/std:c++17")
         env["CXXFLAGS"].insert(0, "/std:c++20")
+        env["CXXFLAGS"].insert(0, "/Zc:preprocessor")
     else:
         env["CXXFLAGS"].remove("-std=c++17")
         env["CXXFLAGS"].insert(0, "-std=c++20")


### PR DESCRIPTION
When trying to compile your demo on Windows I get the following error:
```
$ scons target=template_debug
Compiling shared src\summator.cpp ...
C:\path\to\Godot-SFT\demo\src\tests/sft_example_tests.hpp(38): warning C4003: not enough arguments for function-like macro invocation 'FOR_EACH_HELPER_THREE'
C:\path\to\Godot-SFT\demo\src\tests/sft_example_tests.hpp(38): warning C4003: not enough arguments for function-like macro invocation 'TEST_CONDITION'
C:\path\to\Godot-SFT\demo\src\tests/sft_example_tests.hpp(38): warning C5109: __VA_OPT__ use in macro requires '/Zc:preprocessor'
C:\path\to\Godot-SFT\demo\src\tests\SFT.hpp(102): note: in expansion of macro 'NAMED_TESTS'
C:\path\to\Godot-SFT\demo\src\tests/sft_example_tests.hpp(34): error C2059: syntax error: ';'
C:\path\to\Godot-SFT\demo\src\tests/sft_example_tests.hpp(34): error C2059: syntax error: ')'
C:\path\to\Godot-SFT\demo\src\tests/sft_example_tests.hpp(34): error C2059: syntax error: ','
C:\path\to\Godot-SFT\demo\src\tests/sft_example_tests.hpp(34): fatal error C1003: error count exceeds 100; stopping compilation
scons: *** [src\summator.windows.template_debug.x86_64.obj] Error 2
scons: building terminated because of errors.
```

According to [this stackoverflow comment](https://stackoverflow.com/a/78185169/309083), Windows needs `/Zc:preprocessor` added to the list of `CXXFLAGS`. Upon testing that did indeed fix the issue for me.